### PR TITLE
Add experimental persistant save, load, deletion

### DIFF
--- a/gamejam-coalmining/Nick/dataSaver.gd
+++ b/gamejam-coalmining/Nick/dataSaver.gd
@@ -1,0 +1,99 @@
+extends TextEdit
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+#func _process(delta: float) -> void:
+	#pass
+
+# Called when the node enters the scene tree for the first time.
+func _ready(): # load data
+	print("INIT data")
+	verify_save_directory(SAVE_DIR)
+	#load_data("SAVE_DIR + SAVE_FILE_NAMErobux")
+	load_data("test202410")
+	$".".text = str(data) + $".".text
+	
+
+func _on_text_changed() -> void: # save data
+	print("\nsaving text:")
+	var txt = $".".text
+	print(txt)
+	save_data("test202410", txt)
+
+
+
+const SAVE_DIR = "user://saves/"
+const SAVE_FILE_NAME = "save.json"
+const SECURITY_KEY = "©89SADFH"
+
+#var player_data = PlayerData.new()
+var player_data = {}
+var data # tmp?
+
+func verify_save_directory(path: String):
+	DirAccess.make_dir_absolute(path)
+
+
+func save_data(path: String, new_data): # data = temporary variable probably
+	print('EXPERIMENTAL feature. May break.')
+	path = SAVE_DIR + path
+	var file = FileAccess.open_encrypted_with_pass(path, FileAccess.WRITE, SECURITY_KEY)
+	if file == null:
+		print(FileAccess.get_open_error())
+		return
+
+	#player_data = {
+		#"player_data":{
+			#"health": player_data.health,
+			#"position":{
+				#"x": player_data.global_position.x,
+				#"y": player_data.global_position.y
+			#},
+			#"coins": player_data.coins
+		#}
+	#}
+	
+	#var json_string = JSON.stringify(data, "\t")
+	#file.store_string(json_string)
+	file.store_string(new_data)
+	file.close()
+
+
+func load_data(path: String): # return change later?
+	print('EXPERIMENTAL feature. May break.')
+	path = SAVE_DIR + path
+	if FileAccess.file_exists(path):
+		var file = FileAccess.open_encrypted_with_pass(path, FileAccess.READ, SECURITY_KEY)
+		if file == null:
+			print(FileAccess.get_open_error())
+			return
+
+		var content = file.get_as_text()
+		file.close()
+
+		#var data = JSON.parse_string(content)
+		data = content
+		
+		if data == null:
+			#printerr("Cannot parse %s as a json_string: (%s)" % [path, content])
+			printerr("Cannot parse %s: (%s)" % [path, content])
+			return "gameerror loading data"
+		else:
+			print("Loaded: " + str(data))
+			return data
+
+		# init data + defaults
+
+func del_data(path): # dangerous!
+	#$".".clear() # this will fire .changed() so note two file writes may occur
+	print("Deleting! (may have delay)\n")
+	DirAccess.remove_absolute(SAVE_DIR + path)
+
+	print("Reloading (after 1 second delay)")
+	data = load_data("test202410")
+	$".".text = str(data)
+
+#save_data(SAVE_DIR + SAVE_FILE_NAME)
+func _on_button_pressed() -> void:
+	del_data("test202410")
+	print("no wayy")

--- a/gamejam-coalmining/Nick/testing_envNick.tscn
+++ b/gamejam-coalmining/Nick/testing_envNick.tscn
@@ -1,8 +1,25 @@
-[gd_scene load_steps=2 format=3 uid="uid://cfen35uwvpqc5"]
+[gd_scene load_steps=3 format=3 uid="uid://cfen35uwvpqc5"]
 
 [ext_resource type="PackedScene" uid="uid://b1dt63tvvif5b" path="res://Objects/main_player.tscn" id="1_bvmws"]
+[ext_resource type="Script" path="res://Nick/dataSaver.gd" id="2_lorn5"]
 
 [node name="TestingEnv" type="Node2D"]
 
 [node name="MainPlayer" parent="." instance=ExtResource("1_bvmws")]
 position = Vector2(489, 275)
+
+[node name="TextEditAutosaveThis" type="TextEdit" parent="."]
+offset_right = 119.0
+offset_bottom = 104.0
+placeholder_text = "saving is experimental"
+script = ExtResource("2_lorn5")
+
+[node name="Button" type="Button" parent="."]
+offset_left = 128.0
+offset_top = 168.0
+offset_right = 240.0
+offset_bottom = 248.0
+text = "Delete all yer data (DANGEROUS PLEASE KEEP YOUR MOUSE AWAY)"
+
+[connection signal="text_changed" from="TextEditAutosaveThis" to="TextEditAutosaveThis" method="_on_text_changed"]
+[connection signal="pressed" from="Button" to="TextEditAutosaveThis" method="_on_button_pressed"]


### PR DESCRIPTION
Right now you can:
- Save, load, delete data from scene and it will be saved after leaving and coming back to the game.
- It's experimental and incomplete for general use, it seems reliable for what it does so far.
- At the moment, you'd have to run it from `gamejam-coalmining/Nick/testing_envNick.tscn` since that's the testing ground in general for this project.

Future:
- Make it global.
- Look over the design and probably make adjustments.